### PR TITLE
创建多个Wrapper时崩溃

### DIFF
--- a/jetson_dec_5.0.2/MediaReader.cpp
+++ b/jetson_dec_5.0.2/MediaReader.cpp
@@ -100,6 +100,7 @@ void MediaReader::VideoInit(char *filename)
 {
     int ret;
     char errors[1024];
+    format_ctx_ = avformat_alloc_context();
     if ((ret = avformat_open_input(&format_ctx_, filename, NULL, NULL)) < 0) {
 
         av_strerror(ret, errors, 1024);
@@ -540,6 +541,8 @@ MediaReader::~MediaReader()
         }
     }
     avformat_close_input(&format_ctx_);
+    avformat_free_context(format_ctx_);
+    format_ctx_ =nullptr;
     av_packet_unref(&packet_);
     if(bsf_ctx_){
         av_bsf_free(&bsf_ctx_);


### PR DESCRIPTION
while 循环创建多个Wrapper会崩溃，原因是VideoInit 中没调用avformat_alloc_context申请内存