### PR TITLE
add vui to h264

### DIFF
--- a/jetson_enc_5.0.2/JetsonEnc.cpp
+++ b/jetson_enc_5.0.2/JetsonEnc.cpp
@@ -1379,6 +1379,7 @@ void *JetsonEnc::encode_proc(void *arg)
     ctx.iframe_interval = self->fps * 2;
     ctx.idr_interval = self->fps * 2;
     ctx.insert_sps_pps_at_idr = true;
+    ctx.insert_vui = true;
     // ctx.insert_aud = true;
     ctx.hw_preset_type = V4L2_ENC_HW_PRESET_ULTRAFAST;
     // ctx.alliframes = true;


### PR DESCRIPTION
修复 #10 

使用不添加vui的h264数据时，ffmpeg mux输出rtsp，使用vlc打开此流，会显示帧率为29.97 ，因为vlc会查看h264的vui信息，如果没有则设置成默认帧率（29.97），如果设置vui为真实帧率则没有问题，开启此选项，可以兼容更多的播放端。

不同的播放端解析方式不一样，不添加vui推出的流，ffprobe 解析该rtsp流的fps是没有问题的，我认为是解析的sdp，vlc播放有问题，我认为是解析h264的vui信息而不是sdp。